### PR TITLE
Allow a custom background color

### DIFF
--- a/nerfstudio/models/kplanes.py
+++ b/nerfstudio/models/kplanes.py
@@ -19,7 +19,7 @@ TensorRF implementation.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Dict, List, Optional, Sequence, Tuple, Type, Union
+from typing import Dict, List, Optional, Sequence, Tuple, Type, Literal
 
 import numpy as np
 import torch
@@ -110,6 +110,8 @@ class KPlanesModelConfig(ModelConfig):
     """Proposal loss multiplier."""
     distortion_loss_mult: float = 0.002
     """Distortion loss multiplier."""
+    background_color: Literal["black", "last_sample", "white", "random"] = "black"
+    """The background color that is given to untrained areas. Black seems to do best."""
 
 
 class KPlanesModel(Model):
@@ -161,6 +163,7 @@ class KPlanesModel(Model):
         self.proposal_weights_anneal_max_num_iters = self.config.proposal_weights_anneal_max_num_iters
         self.proposal_weights_anneal_slope = self.config.proposal_weights_anneal_slope
         self.proposal_networks = torch.nn.ModuleList()
+        self.background_color = self.config.background_color
 
         if self.config.use_same_proposal_network:
             assert len(self.proposal_net_args_list) == 1, "Only one proposal network is allowed."
@@ -202,7 +205,7 @@ class KPlanesModel(Model):
         )
 
         # renderers
-        self.renderer_rgb = RGBRenderer(background_color=colors.BLACK)
+        self.renderer_rgb = RGBRenderer(background_color=self.background_color)
         self.renderer_accumulation = AccumulationRenderer()
         self.renderer_depth = DepthRenderer()
 


### PR DESCRIPTION
Added a model config parameter for the background color.

It allows black, white, a random color, or the color of the last sample on the ray ("last_sample"). 

Black and last_sample seem to perform similarly.

Results after 500 iterations:
Black
![image](https://user-images.githubusercontent.com/13520261/223089654-6e1ad1c2-825c-4828-8b39-7c9e9608e6b0.png)

White
![image](https://user-images.githubusercontent.com/13520261/223088752-24df9cd8-8457-47e8-9f29-474ab89d0ed0.png)

Random
![image](https://user-images.githubusercontent.com/13520261/223087396-dd516d8a-8dcf-4313-9e66-b4863bbb2160.png)

Last sample
![image](https://user-images.githubusercontent.com/13520261/223087890-f7aaf523-235f-45e4-b48a-8ec29d3dad8e.png)